### PR TITLE
Error in ApduWrapper

### DIFF
--- a/apduWrapper.go
+++ b/apduWrapper.go
@@ -48,28 +48,27 @@ func Packetize(
 	if !ble {
 		codec.PutUint16(buffer, channel)
 		headerSize += 2
-		buffer = buffer[2:]
 	}
 
 	// Insert tag (1 byte)
-	buffer[0] = 0x05
+	buffer[headerSize] = 0x05
 	headerSize += 1
 
 	var commandLength uint16
 	commandLength = uint16(len(command))
 
 	// Insert sequenceIdx (2 bytes)
-	codec.PutUint16(buffer[1:], sequenceIdx)
+	codec.PutUint16(buffer[headerSize:], sequenceIdx)
 	headerSize += 2
 
 	// Only insert total size of the command in the first package
 	if sequenceIdx == 0 {
 		// Insert sequenceIdx (2 bytes)
-		codec.PutUint16(buffer[3:], commandLength)
+		codec.PutUint16(buffer[headerSize:], commandLength)
 		headerSize += 2
 	}
 
-	buffer = buffer[5:]
+	buffer = buffer[headerSize:]
 	offset = copy(buffer, command)
 	return result, offset, nil
 }


### PR DESCRIPTION
There was a serialization error in the function that created packets in ApduWrapper file.
This PR fixes the issue and adds unit test to validate the fix.